### PR TITLE
Issue #3: 非表示お知らせがダッシュボードに表示されるバグを修正

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,6 +6,7 @@ export async function getAnnouncements(): Promise<Announcement[]> {
   const { data, error } = await supabase
     .from("announcements")
     .select("*")
+    .eq("is_published", true)
     .order("created_at", { ascending: false })
     .limit(3);
 


### PR DESCRIPTION
## 概要
ダッシュボードで非表示設定（`is_published=false`）のお知らせが表示されてしまうバグを修正しました。

## 問題
- お知らせ管理画面で非表示に設定したお知らせがダッシュボードに表示される
- `lib/api.ts`の`getAnnouncements()`関数で`is_published`フィルタが未実装

## 修正内容
- `lib/api.ts`の`getAnnouncements()`関数に`.eq("is_published", true)`フィルタを追加
- 公開済み（`is_published=true`）のお知らせのみがダッシュボードに表示されるよう修正

## 変更ファイル
- `lib/api.ts`: ダッシュボード用お知らせ取得関数の修正

## テスト結果
- ✅ 公開済みお知らせのみダッシュボードに表示される
- ✅ 非表示お知らせはダッシュボードに表示されない
- ✅ お知らせ管理画面では全てのお知らせが表示される（管理者用）

## 影響範囲
- ダッシュボードのお知らせ表示のみ
- 既存の管理機能には影響なし

## Issue
Resolves #3 

🤖 Generated with [Claude Code](https://claude.ai/code)