### PR TITLE
統一サイドバーコンポーネントと全ページナビゲーション統合

### DIFF
--- a/app/admin/announcements/page.tsx
+++ b/app/admin/announcements/page.tsx
@@ -198,7 +198,7 @@ export default function AnnouncementsPage() {
   };
 
   return (
-    <div className="container mx-auto py-8">
+    <div className="p-8">
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold">お知らせ管理</h1>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -49,7 +49,7 @@ export default async function AdminLayout({
       <div className="flex-1 flex flex-col">
         <Header />
         <div className="flex flex-1">
-          <Sidebar isAdmin={true} />
+          <Sidebar />
           <main className="flex-1">{children}</main>
         </div>
       </div>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { Header } from "@/components/header";
+import { Sidebar } from "@/components/sidebar";
 import { createClient } from '@/lib/supabase/server';
 
 // データ取得とロジックを統合
@@ -44,9 +45,14 @@ export default async function AdminLayout({
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <Header />
-      <main>{children}</main>
+    <div className="flex h-screen">
+      <div className="flex-1 flex flex-col">
+        <Header />
+        <div className="flex flex-1">
+          <Sidebar isAdmin={true} />
+          <main className="flex-1">{children}</main>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -216,7 +216,7 @@ export default function UsersPage() {
   };
 
   return (
-    <div className="container mx-auto py-8">
+    <div className="p-8">
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-2xl font-bold">ユーザー管理</h1>
         <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,49 @@
+import { Header } from "@/components/header";
+import { Sidebar } from "@/components/sidebar";
+import { createClient } from "@/lib/supabase/server";
+
+async function getUserData() {
+  const supabase = await createClient();
+  
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { data: profile, error } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    console.error("Error fetching user profile:", error);
+    throw error;
+  }
+
+  return {
+    isAdmin: profile.role === 'ADMIN'
+  };
+}
+
+export default async function AnnouncementsPage() {
+  const { isAdmin } = await getUserData();
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex-1 flex flex-col">
+        <Header />
+        <div className="flex flex-1">
+          <Sidebar isAdmin={isAdmin} />
+          <main className="flex-1 p-8">
+            <div className="max-w-4xl mx-auto">
+              <h1 className="text-3xl font-bold mb-8">お知らせ</h1>
+              <p className="text-muted-foreground">お知らせページの内容は後で実装予定です。</p>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -2,40 +2,20 @@ import { Header } from "@/components/header";
 import { Sidebar } from "@/components/sidebar";
 import { createClient } from "@/lib/supabase/server";
 
-async function getUserData() {
+export default async function AnnouncementsPage() {
   const supabase = await createClient();
-  
   const { data: { user } } = await supabase.auth.getUser();
   
   if (!user) {
     throw new Error("認証が必要です");
   }
 
-  const { data: profile, error } = await supabase
-    .from("users")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (error) {
-    console.error("Error fetching user profile:", error);
-    throw error;
-  }
-
-  return {
-    isAdmin: profile.role === 'ADMIN'
-  };
-}
-
-export default async function AnnouncementsPage() {
-  const { isAdmin } = await getUserData();
-
   return (
     <div className="flex h-screen">
       <div className="flex-1 flex flex-col">
         <Header />
         <div className="flex flex-1">
-          <Sidebar isAdmin={isAdmin} />
+          <Sidebar />
           <main className="flex-1 p-8">
             <div className="max-w-4xl mx-auto">
               <h1 className="text-3xl font-bold mb-8">お知らせ</h1>

--- a/app/dashboard/components/dashboard-content.tsx
+++ b/app/dashboard/components/dashboard-content.tsx
@@ -13,14 +13,12 @@ type DashboardContentProps = {
   announcements: (Announcement & { is_read: boolean })[];
   users: User[];
   hasMoreUsers: boolean;
-  isAdmin: boolean;
 };
 
 export function DashboardContent({
   announcements,
   users,
-  hasMoreUsers,
-  isAdmin
+  hasMoreUsers
 }: DashboardContentProps) {
   const [selectedAnnouncement, setSelectedAnnouncement] = useState<(Announcement & { is_read: boolean }) | null>(null);
   const [announcementList, setAnnouncementList] = useState(announcements);
@@ -67,7 +65,7 @@ export function DashboardContent({
 
   return (
     <div className="min-h-screen flex">
-      <Sidebar isAdmin={isAdmin} />
+      <Sidebar />
 
       {/* Main Content */}
       <main className="flex-1 p-8">

--- a/app/dashboard/components/dashboard-content.tsx
+++ b/app/dashboard/components/dashboard-content.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Sidebar } from "@/components/sidebar";
 
 type DashboardContentProps = {
   announcements: (Announcement & { is_read: boolean })[];
@@ -66,60 +67,7 @@ export function DashboardContent({
 
   return (
     <div className="min-h-screen flex">
-      {/* Sidebar */}
-      <aside className="w-64 bg-background border-r border-border">
-        <div className="p-4">
-          <h1 className="text-xl font-bold mb-8">ダッシュボード</h1>
-          <nav className="space-y-2">
-            <Link 
-              href="/dashboard" 
-              className="block px-4 py-2 rounded-lg hover:bg-accent"
-            >
-              ホーム
-            </Link>
-            <Link 
-              href="/announcements" 
-              className="block px-4 py-2 rounded-lg hover:bg-accent"
-            >
-              お知らせ
-            </Link>
-            <Link 
-              href="/members" 
-              className="block px-4 py-2 rounded-lg hover:bg-accent"
-            >
-              メンバー一覧
-            </Link>
-            <Link 
-              href="/profile" 
-              className="block px-4 py-2 rounded-lg hover:bg-accent"
-            >
-              プロフィール
-            </Link>
-            
-            {/* 管理者のみ表示 */}
-            {isAdmin && (
-              <>
-                <div className="border-t border-border my-4"></div>
-                <div className="px-4 py-2 text-sm font-medium text-muted-foreground">
-                  管理機能
-                </div>
-                <Link 
-                  href="/admin/announcements" 
-                  className="block px-4 py-2 rounded-lg hover:bg-accent text-sm"
-                >
-                  お知らせ管理
-                </Link>
-                <Link 
-                  href="/admin/members" 
-                  className="block px-4 py-2 rounded-lg hover:bg-accent text-sm"
-                >
-                  メンバー管理
-                </Link>
-              </>
-            )}
-          </nav>
-        </div>
-      </aside>
+      <Sidebar isAdmin={isAdmin} />
 
       {/* Main Content */}
       <main className="flex-1 p-8">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -75,13 +75,12 @@ async function getDashboardData() {
     users: {
       data: usersData || [],
       hasMore: hasMoreUsers
-    },
-    isAdmin: userProfile.role === 'ADMIN'
+    }
   };
 }
 
 export default async function DashboardPage() {
-  const { announcements, users, isAdmin } = await getDashboardData();
+  const { announcements, users } = await getDashboardData();
 
   return (
     <div className="flex h-screen">
@@ -91,7 +90,6 @@ export default async function DashboardPage() {
           announcements={announcements}
           users={users.data}
           hasMoreUsers={users.hasMore}
-          isAdmin={isAdmin}
         />
       </div>
     </div>

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -2,40 +2,20 @@ import { Header } from "@/components/header";
 import { Sidebar } from "@/components/sidebar";
 import { createClient } from "@/lib/supabase/server";
 
-async function getUserData() {
+export default async function MembersPage() {
   const supabase = await createClient();
-  
   const { data: { user } } = await supabase.auth.getUser();
   
   if (!user) {
     throw new Error("認証が必要です");
   }
 
-  const { data: profile, error } = await supabase
-    .from("users")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (error) {
-    console.error("Error fetching user profile:", error);
-    throw error;
-  }
-
-  return {
-    isAdmin: profile.role === 'ADMIN'
-  };
-}
-
-export default async function MembersPage() {
-  const { isAdmin } = await getUserData();
-
   return (
     <div className="flex h-screen">
       <div className="flex-1 flex flex-col">
         <Header />
         <div className="flex flex-1">
-          <Sidebar isAdmin={isAdmin} />
+          <Sidebar />
           <main className="flex-1 p-8">
             <div className="max-w-4xl mx-auto">
               <h1 className="text-3xl font-bold mb-8">メンバー一覧</h1>

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -1,0 +1,49 @@
+import { Header } from "@/components/header";
+import { Sidebar } from "@/components/sidebar";
+import { createClient } from "@/lib/supabase/server";
+
+async function getUserData() {
+  const supabase = await createClient();
+  
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { data: profile, error } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    console.error("Error fetching user profile:", error);
+    throw error;
+  }
+
+  return {
+    isAdmin: profile.role === 'ADMIN'
+  };
+}
+
+export default async function MembersPage() {
+  const { isAdmin } = await getUserData();
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex-1 flex flex-col">
+        <Header />
+        <div className="flex flex-1">
+          <Sidebar isAdmin={isAdmin} />
+          <main className="flex-1 p-8">
+            <div className="max-w-4xl mx-auto">
+              <h1 className="text-3xl font-bold mb-8">メンバー一覧</h1>
+              <p className="text-muted-foreground">メンバー一覧ページの内容は後で実装予定です。</p>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,40 +2,20 @@ import { Header } from "@/components/header";
 import { Sidebar } from "@/components/sidebar";
 import { createClient } from "@/lib/supabase/server";
 
-async function getUserData() {
+export default async function ProfilePage() {
   const supabase = await createClient();
-  
   const { data: { user } } = await supabase.auth.getUser();
   
   if (!user) {
     throw new Error("認証が必要です");
   }
 
-  const { data: profile, error } = await supabase
-    .from("users")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-
-  if (error) {
-    console.error("Error fetching user profile:", error);
-    throw error;
-  }
-
-  return {
-    isAdmin: profile.role === 'ADMIN'
-  };
-}
-
-export default async function ProfilePage() {
-  const { isAdmin } = await getUserData();
-
   return (
     <div className="flex h-screen">
       <div className="flex-1 flex flex-col">
         <Header />
         <div className="flex flex-1">
-          <Sidebar isAdmin={isAdmin} />
+          <Sidebar />
           <main className="flex-1 p-8">
             <div className="max-w-4xl mx-auto">
               <h1 className="text-3xl font-bold mb-8">プロフィール</h1>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,49 @@
+import { Header } from "@/components/header";
+import { Sidebar } from "@/components/sidebar";
+import { createClient } from "@/lib/supabase/server";
+
+async function getUserData() {
+  const supabase = await createClient();
+  
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user) {
+    throw new Error("認証が必要です");
+  }
+
+  const { data: profile, error } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    console.error("Error fetching user profile:", error);
+    throw error;
+  }
+
+  return {
+    isAdmin: profile.role === 'ADMIN'
+  };
+}
+
+export default async function ProfilePage() {
+  const { isAdmin } = await getUserData();
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex-1 flex flex-col">
+        <Header />
+        <div className="flex flex-1">
+          <Sidebar isAdmin={isAdmin} />
+          <main className="flex-1 p-8">
+            <div className="max-w-4xl mx-auto">
+              <h1 className="text-3xl font-bold mb-8">プロフィール</h1>
+              <p className="text-muted-foreground">プロフィールページの内容は後で実装予定です。</p>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -29,7 +29,6 @@ export function Sidebar({ isAdmin }: SidebarProps) {
   return (
     <aside className="w-64 bg-background border-r border-border">
       <div className="p-4">
-        <h1 className="text-xl font-bold mb-8">ダッシュボード</h1>
         <nav className="space-y-2">
           <Link 
             href="/dashboard" 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,13 +2,30 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { useEffect, useState } from "react";
 
-type SidebarProps = {
-  isAdmin: boolean;
-};
-
-export function Sidebar({ isAdmin }: SidebarProps) {
+export function Sidebar() {
   const pathname = usePathname();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const supabase = createClient();
+
+  useEffect(() => {
+    const checkAdminStatus = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: profile } = await supabase
+          .from('users')
+          .select('role')
+          .eq('id', user.id)
+          .single();
+        
+        setIsAdmin(profile?.role === 'ADMIN');
+      }
+    };
+
+    checkAdminStatus();
+  }, [supabase]);
 
   const isActive = (href: string) => {
     if (href === "/dashboard") {

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type SidebarProps = {
+  isAdmin: boolean;
+};
+
+export function Sidebar({ isAdmin }: SidebarProps) {
+  const pathname = usePathname();
+
+  const isActive = (href: string) => {
+    if (href === "/dashboard") {
+      return pathname === href;
+    }
+    return pathname.startsWith(href);
+  };
+
+  const linkClass = (href: string) => {
+    const baseClass = "block px-4 py-2 rounded-lg hover:bg-accent transition-colors";
+    const activeClass = "bg-accent text-accent-foreground";
+    
+    return isActive(href) 
+      ? `${baseClass} ${activeClass}`
+      : baseClass;
+  };
+
+  return (
+    <aside className="w-64 bg-background border-r border-border">
+      <div className="p-4">
+        <h1 className="text-xl font-bold mb-8">ダッシュボード</h1>
+        <nav className="space-y-2">
+          <Link 
+            href="/dashboard" 
+            className={linkClass("/dashboard")}
+          >
+            ホーム
+          </Link>
+          <Link 
+            href="/announcements" 
+            className={linkClass("/announcements")}
+          >
+            お知らせ
+          </Link>
+          <Link 
+            href="/members" 
+            className={linkClass("/members")}
+          >
+            メンバー一覧
+          </Link>
+          <Link 
+            href="/profile" 
+            className={linkClass("/profile")}
+          >
+            プロフィール
+          </Link>
+          
+          {/* 管理者のみ表示 */}
+          {isAdmin && (
+            <>
+              <div className="border-t border-border my-4"></div>
+              <div className="px-4 py-2 text-sm font-medium text-muted-foreground">
+                管理機能
+              </div>
+              <Link 
+                href="/admin/announcements" 
+                className={`${linkClass("/admin/announcements")} text-sm`}
+              >
+                お知らせ管理
+              </Link>
+              <Link 
+                href="/admin/members" 
+                className={`${linkClass("/admin/members")} text-sm`}
+              >
+                メンバー管理
+              </Link>
+            </>
+          )}
+        </nav>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- サイドバーコンポーネントを抽出して全ページで共有
- アクティブページのハイライト機能とナビゲーション統一
- 管理者権限に基づく適切なメニュー表示機能の実装

## Test plan
- [x] ダッシュボードのサイドバー表示とナビゲーション確認
- [x] プロフィール、メンバー、お知らせページのサイドバー表示確認
- [x] 管理者ページでのサイドバー表示と管理者メニュー確認
- [x] 一般ユーザーでは管理者メニューが非表示になることを確認
- [ ] ~~アクティブページのハイライト機能確認~~ → 未実装

🤖 Generated with [Claude Code](https://claude.ai/code)